### PR TITLE
Remove ambiguity behind 0x0 writes

### DIFF
--- a/Adafruit_MPRLS.cpp
+++ b/Adafruit_MPRLS.cpp
@@ -119,8 +119,8 @@ float Adafruit_MPRLS::readPressure(void) {
 uint32_t Adafruit_MPRLS::readData(void) {
   _i2c->beginTransmission(_i2c_addr);
   _i2c->write(0xAA);   // command to read pressure
-  _i2c->write(0x0);
-  _i2c->write(0x0);
+  _i2c->write((byte)0x0);
+  _i2c->write((byte)0x0);
   _i2c->endTransmission();
   
   // Use the gpio to tell end of conversion


### PR DESCRIPTION
**Describe the scope of your change**

I downloaded this library to work with the MPRLS sensor from the Adafruit store with a Feather. I found that this library fails to compile on Feather but successfully compiles on Arduino. When compiling with the Feather, the problem with the code was with ambiguous writes. To fix this, I added a cast to byte to remove ambiguity.

**Describe any known limitations with your change**

I tested the library on Feather and Arduino with the example code. The library compiles successfully on both platforms, and the sensor works on both platforms as well.