### PR TITLE
v1.1.0 - support for different models + timeout + exposed sensor status

### DIFF
--- a/Adafruit_MPRLS.cpp
+++ b/Adafruit_MPRLS.cpp
@@ -86,8 +86,7 @@ Adafruit_MPRLS::Adafruit_MPRLS(int8_t reset_pin, int8_t EOC_pin,
     @returns True on success, False if sensor not found
 */
 /**************************************************************************/
-bool Adafruit_MPRLS::begin(uint8_t i2c_addr, TwoWire* twoWire) {
-//boolean Adafruit_MPRLS::begin(uint8_t i2c_addr, TwoWire *twoWire) {
+boolean Adafruit_MPRLS::begin(uint8_t i2c_addr, TwoWire* twoWire) {
   _i2c_addr = i2c_addr;
   _i2c = twoWire;
 

--- a/Adafruit_MPRLS.cpp
+++ b/Adafruit_MPRLS.cpp
@@ -26,18 +26,20 @@
  *
  * MIT license, all text here must be included in any redistribution.
  *
+ * @section changes Changes
+ *
  * Changes by arkhipenko (https://github.com/arkhipenko) (December 2020)
  * Overall, with all the defaults this should be 99% backwards compatible and could be a drop-in
  * replacement. The 1% difference is that the library can now return NAN due to a timeout
- * - added parameters to constructor to support different transfer function curves
- *   and a factor for conversion to desired units
- * - PSI_min and PSI_max are 16 bit unsigned to support values > 255
- * - readPressure(void) method calculates based on the provided curve values,
- *   and converts to desired units
- * - readData(void) method may return NAN in case of timeout (20 millis currently - could be changed)
- * - public variable lastStatus could be accessed to check the error bits in case of a NAN value
- * - begin() method updates lastStatus, so in case of a failure, the reason could be checked explicitly
- *   success is "true" if status == MPRLS_STATUS_POWERED and no other bits are set
+ *   - added parameters to constructor to support different transfer function curves
+ *     and a factor for conversion to desired units
+ *   - PSI_min and PSI_max are 16 bit unsigned to support values > 255
+ *   - readPressure(void) method calculates based on the provided curve values,
+ *     and converts to desired units
+ *   - readData(void) method may return NAN in case of timeout (20 millis currently - could be changed)
+ *   - public variable lastStatus could be accessed to check the error bits in case of a NAN value
+ *   - begin() method updates lastStatus, so in case of a failure, the reason could be checked explicitly
+ *     success is "true" if status == MPRLS_STATUS_POWERED and no other bits are set
  */
 
 #if (ARDUINO >= 100)

--- a/Adafruit_MPRLS.cpp
+++ b/Adafruit_MPRLS.cpp
@@ -29,17 +29,21 @@
  * @section changes Changes
  *
  * Changes by arkhipenko (https://github.com/arkhipenko) (December 2020)
- * Overall, with all the defaults this should be 99% backwards compatible and could be a drop-in
- * replacement. The 1% difference is that the library can now return NAN due to a timeout
- *   - added parameters to constructor to support different transfer function curves
- *     and a factor for conversion to desired units
+ * Overall, with all the defaults this should be 99% backwards compatible and
+ * could be a drop-in replacement. The 1% difference is that the library can now
+ * return NAN due to a timeout
+ *   - added parameters to constructor to support different transfer function
+ * curves and a factor for conversion to desired units
  *   - PSI_min and PSI_max are 16 bit unsigned to support values > 255
  *   - readPressure(void) method calculates based on the provided curve values,
  *     and converts to desired units
- *   - readData(void) method may return NAN in case of timeout (20 millis currently - could be changed)
- *   - public variable lastStatus could be accessed to check the error bits in case of a NAN value
- *   - begin() method updates lastStatus, so in case of a failure, the reason could be checked explicitly
- *     success is "true" if status == MPRLS_STATUS_POWERED and no other bits are set
+ *   - readData(void) method may return NAN in case of timeout (20 millis
+ * currently - could be changed)
+ *   - public variable lastStatus could be accessed to check the error bits in
+ * case of a NAN value
+ *   - begin() method updates lastStatus, so in case of a failure, the reason
+ * could be checked explicitly success is "true" if status ==
+ * MPRLS_STATUS_POWERED and no other bits are set
  */
 
 #if (ARDUINO >= 100)
@@ -59,8 +63,10 @@
    skip
     @param PSI_min The minimum PSI measurement range of the sensor, default 0
     @param PSI_max The maximum PSI measurement range of the sensor, default 25
-    @param OUTPUT_min The minimum transfer function curve value in %, default 10%
-    @param OUTPUT_max The maximum transfer function curve value in %, default 90%    
+    @param OUTPUT_min The minimum transfer function curve value in %, default
+   10%
+    @param OUTPUT_max The maximum transfer function curve value in %, default
+   90%
     @param K Conversion Factor to desired units, default is PSI to HPA
 */
 /**************************************************************************/
@@ -72,8 +78,8 @@ Adafruit_MPRLS::Adafruit_MPRLS(int8_t reset_pin, int8_t EOC_pin,
   _eoc = EOC_pin;
   _PSI_min = PSI_min;
   _PSI_max = PSI_max;
-  _OUTPUT_min = (uint32_t) ((float) COUNTS_224 * (OUTPUT_min / 100.0) + 0.5);
-  _OUTPUT_max = (uint32_t) ((float) COUNTS_224 * (OUTPUT_max / 100.0) + 0.5);
+  _OUTPUT_min = (uint32_t)((float)COUNTS_224 * (OUTPUT_min / 100.0) + 0.5);
+  _OUTPUT_max = (uint32_t)((float)COUNTS_224 * (OUTPUT_max / 100.0) + 0.5);
   _K = K;
 }
 
@@ -86,7 +92,7 @@ Adafruit_MPRLS::Adafruit_MPRLS(int8_t reset_pin, int8_t EOC_pin,
     @returns True on success, False if sensor not found
 */
 /**************************************************************************/
-boolean Adafruit_MPRLS::begin(uint8_t i2c_addr, TwoWire* twoWire) {
+boolean Adafruit_MPRLS::begin(uint8_t i2c_addr, TwoWire *twoWire) {
   _i2c_addr = i2c_addr;
   _i2c = twoWire;
 
@@ -106,22 +112,23 @@ boolean Adafruit_MPRLS::begin(uint8_t i2c_addr, TwoWire* twoWire) {
   delay(10); // startup timing
 
   // Serial.print("Status: ");
-//  lastStatus = readStatus();
+  //  lastStatus = readStatus();
   // Serial.println(stat);
-//  return lastStatus;
-  return ( (readStatus() & MPRLS_STATUS_MASK) == MPRLS_STATUS_POWERED);
+  //  return lastStatus;
+  return ((readStatus() & MPRLS_STATUS_MASK) == MPRLS_STATUS_POWERED);
 }
 
 /**************************************************************************/
 /*!
     @brief Read and calculate the pressure
     @returns The measured pressure, in hPa on success, NAN on failure
-    @param  The conversion factor to the desired units. Default is from PSI rto hPa
+    @param  The conversion factor to the desired units. Default is from PSI rto
+   hPa
 */
 /**************************************************************************/
 float Adafruit_MPRLS::readPressure(void) {
   uint32_t raw_psi = readData();
-  if ( raw_psi == 0xFFFFFFFF || _OUTPUT_min == _OUTPUT_max ) {
+  if (raw_psi == 0xFFFFFFFF || _OUTPUT_min == _OUTPUT_max) {
     return NAN;
   }
 
@@ -151,14 +158,16 @@ uint32_t Adafruit_MPRLS::readData(void) {
   uint32_t t = millis();
   if (_eoc != -1) {
     while (!digitalRead(_eoc)) {
-      if ( millis() - t > MPRLS_READ_TIMEOUT ) return 0xFFFFFFFF; // timeout
+      if (millis() - t > MPRLS_READ_TIMEOUT)
+        return 0xFFFFFFFF; // timeout
     }
   } else {
     // check the status byte
-//    uint8_t stat;
+    //    uint8_t stat;
     while ((lastStatus = readStatus()) & MPRLS_STATUS_BUSY) {
       // Serial.print("Status: "); Serial.println(stat, HEX);
-      if ( millis() - t > MPRLS_READ_TIMEOUT ) return 0xFFFFFFFF; // timeout
+      if (millis() - t > MPRLS_READ_TIMEOUT)
+        return 0xFFFFFFFF; // timeout
     }
   }
   _i2c->requestFrom(_i2c_addr, (uint8_t)4);
@@ -191,5 +200,5 @@ uint8_t Adafruit_MPRLS::readStatus(void) {
   _i2c->requestFrom(_i2c_addr, (uint8_t)1);
 
   lastStatus = _i2c->read();
-  return lastStatus; 
+  return lastStatus;
 }

--- a/Adafruit_MPRLS.cpp
+++ b/Adafruit_MPRLS.cpp
@@ -112,9 +112,7 @@ boolean Adafruit_MPRLS::begin(uint8_t i2c_addr, TwoWire *twoWire) {
   delay(10); // startup timing
 
   // Serial.print("Status: ");
-  //  lastStatus = readStatus();
   // Serial.println(stat);
-  //  return lastStatus;
   return ((readStatus() & MPRLS_STATUS_MASK) == MPRLS_STATUS_POWERED);
 }
 
@@ -122,8 +120,7 @@ boolean Adafruit_MPRLS::begin(uint8_t i2c_addr, TwoWire *twoWire) {
 /*!
     @brief Read and calculate the pressure
     @returns The measured pressure, in hPa on success, NAN on failure
-    @param  The conversion factor to the desired units. Default is from PSI rto
-   hPa
+
 */
 /**************************************************************************/
 float Adafruit_MPRLS::readPressure(void) {

--- a/Adafruit_MPRLS.h
+++ b/Adafruit_MPRLS.h
@@ -32,7 +32,8 @@
 #define MPRLS_STATUS_MATHSAT (0x01) ///< Status bit for math saturation
 #define COUNTS_224 (16777216L)      ///< Constant: 2^24
 #define PSI_to_HPA (68.947572932)   ///< Constant: PSI to HPA conversion factor
-#define MPRLS_STATUS_MASK (0b01100101) ///< Sensor status mask: only these bits are set
+#define MPRLS_STATUS_MASK                                                      \
+  (0b01100101) ///< Sensor status mask: only these bits are set
 
 /**************************************************************************/
 /*!

--- a/Adafruit_MPRLS.h
+++ b/Adafruit_MPRLS.h
@@ -24,11 +24,15 @@
 #endif
 #include "Wire.h"
 
-#define MPRLS_DEFAULT_ADDR (0x18)   ///< Most common I2C address
-#define MPRLS_STATUS_POWERED (0x40) ///< Status SPI powered bit
-#define MPRLS_STATUS_BUSY (0x20)    ///< Status busy bit
-#define MPRLS_STATUS_FAILED (0x04)  ///< Status bit for integrity fail
-#define MPRLS_STATUS_MATHSAT (0x01) ///< Status bit for math saturation
+#define MPRLS_DEFAULT_ADDR    (0x18)   ///< Most common I2C address
+#define MPRLS_READ_TIMEOUT    (20)    ///< millis
+#define MPRLS_STATUS_POWERED  (0x40) ///< Status SPI powered bit
+#define MPRLS_STATUS_BUSY     (0x20)    ///< Status busy bit
+#define MPRLS_STATUS_FAILED   (0x04)  ///< Status bit for integrity fail
+#define MPRLS_STATUS_MATHSAT  (0x01) ///< Status bit for math saturation
+#define COUNTS_224            (16777216L) //  2^24
+#define PSI_to_HPA            (68.947572932)
+#define MPRLS_STATUS_MASK     (0b01100101)  //  only these bits are set
 
 /**************************************************************************/
 /*!
@@ -39,20 +43,24 @@
 class Adafruit_MPRLS {
 public:
   Adafruit_MPRLS(int8_t reset_pin = -1, int8_t EOC_pin = -1,
-                 uint8_t PSI_min = 0, uint8_t PSI_max = 25);
+                 uint16_t PSI_min = 0, uint16_t PSI_max = 25,
+                 float OUTPUT_min = 10, float OUTPUT_max = 90, float K = PSI_to_HPA);
 
-  boolean begin(uint8_t i2c_addr = MPRLS_DEFAULT_ADDR,
-                TwoWire *twoWire = &Wire);
+  bool      begin(uint8_t i2c_addr = MPRLS_DEFAULT_ADDR,
+                  TwoWire* twoWire = &Wire);
 
-  uint8_t readStatus(void);
-  float readPressure(void);
+  uint8_t   readStatus(void);
+  float     readPressure(void);
 
+  uint8_t   lastStatus;
 private:
-  uint32_t readData(void);
+  uint32_t  readData(void);
 
-  uint8_t _i2c_addr;
-  int8_t _reset, _eoc;
-  uint8_t _PSI_min, _PSI_max;
+  uint8_t   _i2c_addr;
+  int8_t    _reset, _eoc;
+  uint16_t  _PSI_min, _PSI_max;
+  uint32_t  _OUTPUT_min, _OUTPUT_max;
+  float     _K;
 
-  TwoWire *_i2c;
+  TwoWire*  _i2c;
 };

--- a/Adafruit_MPRLS.h
+++ b/Adafruit_MPRLS.h
@@ -30,9 +30,9 @@
 #define MPRLS_STATUS_BUSY (0x20)    ///< Status busy bit
 #define MPRLS_STATUS_FAILED (0x04)  ///< Status bit for integrity fail
 #define MPRLS_STATUS_MATHSAT (0x01) ///< Status bit for math saturation
-#define COUNTS_224 (16777216L)      //  2^24
-#define PSI_to_HPA (68.947572932)
-#define MPRLS_STATUS_MASK (0b01100101) //  only these bits are set
+#define COUNTS_224 (16777216L)      ///< Constant: 2^24
+#define PSI_to_HPA (68.947572932)   ///< Constant: PSI to HPA conversion factor
+#define MPRLS_STATUS_MASK (0b01100101) ///< Sensor status mask: only these bits are set
 
 /**************************************************************************/
 /*!
@@ -52,7 +52,7 @@ public:
   uint8_t readStatus(void);
   float readPressure(void);
 
-  uint8_t lastStatus;
+  uint8_t lastStatus; /*!< status byte after last operation */
 
 private:
   uint32_t readData(void);

--- a/Adafruit_MPRLS.h
+++ b/Adafruit_MPRLS.h
@@ -24,15 +24,15 @@
 #endif
 #include "Wire.h"
 
-#define MPRLS_DEFAULT_ADDR    (0x18)   ///< Most common I2C address
-#define MPRLS_READ_TIMEOUT    (20)    ///< millis
-#define MPRLS_STATUS_POWERED  (0x40) ///< Status SPI powered bit
-#define MPRLS_STATUS_BUSY     (0x20)    ///< Status busy bit
-#define MPRLS_STATUS_FAILED   (0x04)  ///< Status bit for integrity fail
-#define MPRLS_STATUS_MATHSAT  (0x01) ///< Status bit for math saturation
-#define COUNTS_224            (16777216L) //  2^24
-#define PSI_to_HPA            (68.947572932)
-#define MPRLS_STATUS_MASK     (0b01100101)  //  only these bits are set
+#define MPRLS_DEFAULT_ADDR (0x18)   ///< Most common I2C address
+#define MPRLS_READ_TIMEOUT (20)     ///< millis
+#define MPRLS_STATUS_POWERED (0x40) ///< Status SPI powered bit
+#define MPRLS_STATUS_BUSY (0x20)    ///< Status busy bit
+#define MPRLS_STATUS_FAILED (0x04)  ///< Status bit for integrity fail
+#define MPRLS_STATUS_MATHSAT (0x01) ///< Status bit for math saturation
+#define COUNTS_224 (16777216L)      //  2^24
+#define PSI_to_HPA (68.947572932)
+#define MPRLS_STATUS_MASK (0b01100101) //  only these bits are set
 
 /**************************************************************************/
 /*!
@@ -44,23 +44,24 @@ class Adafruit_MPRLS {
 public:
   Adafruit_MPRLS(int8_t reset_pin = -1, int8_t EOC_pin = -1,
                  uint16_t PSI_min = 0, uint16_t PSI_max = 25,
-                 float OUTPUT_min = 10, float OUTPUT_max = 90, float K = PSI_to_HPA);
+                 float OUTPUT_min = 10, float OUTPUT_max = 90,
+                 float K = PSI_to_HPA);
 
-  bool      begin(uint8_t i2c_addr = MPRLS_DEFAULT_ADDR,
-                  TwoWire* twoWire = &Wire);
+  bool begin(uint8_t i2c_addr = MPRLS_DEFAULT_ADDR, TwoWire *twoWire = &Wire);
 
-  uint8_t   readStatus(void);
-  float     readPressure(void);
+  uint8_t readStatus(void);
+  float readPressure(void);
 
-  uint8_t   lastStatus;
+  uint8_t lastStatus;
+
 private:
-  uint32_t  readData(void);
+  uint32_t readData(void);
 
-  uint8_t   _i2c_addr;
-  int8_t    _reset, _eoc;
-  uint16_t  _PSI_min, _PSI_max;
-  uint32_t  _OUTPUT_min, _OUTPUT_max;
-  float     _K;
+  uint8_t _i2c_addr;
+  int8_t _reset, _eoc;
+  uint16_t _PSI_min, _PSI_max;
+  uint32_t _OUTPUT_min, _OUTPUT_max;
+  float _K;
 
-  TwoWire*  _i2c;
+  TwoWire *_i2c;
 };

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit MPRLS Library
-version=1.0.7
+version=1.1.0
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library for MPRLS series pressure sensors


### PR DESCRIPTION
 Changes by arkhipenko (https://github.com/arkhipenko) (December 2020)
 Overall, with all the defaults this should be 99% backwards compatible and could be a drop-in
 replacement. The 1% difference is that the library can now return NAN due to a timeout
 - added parameters to the constructor to support different transfer function curves
   and a factor for conversion to desired units
 - PSI_min and PSI_max are 16 bit unsigned to support values > 255
 - readPressure(void) method calculates based on the provided curve values,
   and converts to desired units
 - readData(void) method may return NAN in case of timeout (20 millis currently - could be changed)
 - public variable lastStatus could be accessed to check the error bits in case of a NAN value
 - begin() method updates lastStatus, so in case of a failure, the reason could be checked explicitly
   success is "true" if status == MPRLS_STATUS_POWERED and no other bits are set
